### PR TITLE
minor bug in Optimize_params.R

### DIFF
--- a/R/Optimize_params.R
+++ b/R/Optimize_params.R
@@ -997,7 +997,7 @@ SlaveCluster_doe <-function(task, Set_parameters, object, object_mslevel,
 calculateSet_doe <- function(object, object_mslevel, Set_parameters, task = 1,
                              BPPARAM = bpparam()) {
   
-  if (length(Set_parameters) < 31){ # deal with the usual processing case
+  if (sum(lengths(Set_parameters)) < 31){ # deal with the usual processing case
     param <- updateRawSpectraParam(Set_parameters)
   } else { # deal with the optimization case, usaully 44 (33 each set)
     param <- updateRawSpectraParam(Set_parameters[[task]])


### PR DESCRIPTION
Hi @Zhiqiang-PANG,

In my efforts to get OptiLCMS parameter optimization working with custom parameters, I believe I discovered a bug in calculateSet_doe.

Specifically, the function checks the length() of Set_parameters to determine how to call updateRawSpectraParam() (<31 --> pass on Set_parameters directly; otherwise pass on sub-set).

However, since Set_parameters is a list of lists (!), length() actually only returns the number of sub-lists (i.e., number of parameter sets), rather than the total number of elements. If the DoE setup has less than 31 parameter sets, the entire DoE gets passed on to updateRawSpectraParam(), leading to errors.

Using sum(lengths()) instead avoids this issue by counting the total number of list entries (across lists), so 20-30 per parameter set, leading to correct behavior.