### PR TITLE
Get memsize in macOS correctly

### DIFF
--- a/R/Optimize_params.R
+++ b/R/Optimize_params.R
@@ -746,7 +746,7 @@ ExperimentsCluster_doe <-function(object, object_mslevel,params,
       if (.Platform$OS.type == "unix") {
         memtotal <-
           ceiling(as.numeric(
-            system("awk '/MemTotal/ {print $2}' /proc/meminfo", intern = TRUE)
+            system("sysctl -a | awk '/memsize:/ {print $2}'", intern = TRUE)
           ) / 1024 / 1024)
       }
       if (.Platform$OS.type == "windows") {

--- a/R/Optimize_params.R
+++ b/R/Optimize_params.R
@@ -743,13 +743,23 @@ ExperimentsCluster_doe <-function(object, object_mslevel,params,
       
       data.size <- round(as.numeric(object.size(object) / 1024 / 1024), 1)
       
-      if (.Platform$OS.type == "unix") {
+      # detect platform
+      sysname = Sys.info()[['sysname']]
+      if (sysname == "Linux") {
         memtotal <-
           ceiling(as.numeric(
-            system("sysctl -a | awk '/memsize:/ {print $2}'", intern = TRUE)
+            system("cat /proc/meminfo | awk '/MemTotal:/ {print $2}'", intern = TRUE)
           ) / 1024 / 1024)
       }
-      if (.Platform$OS.type == "windows") {
+
+      if (sysname == "Darwin"){
+        memtotal <-
+          ceiling(as.numeric(
+            system("sysctl hw.memsize | awk '{print $2}'", intern = TRUE)
+          ) / 1024 / 1024 / 1024)
+      }
+      
+      if (sysname == "Windows") {
         memtotal <-
           ceiling(as.numeric(gsub(
             "\r", "", gsub(


### PR DESCRIPTION
This package failed to run in macOS platform, due to the method getting memory size is not applicable, although macOS is also a unix-based system.

This pull request fixed this issue.