### PR TITLE
Add array header to mzClust.cpp

### DIFF
--- a/src/mzClust.cpp
+++ b/src/mzClust.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <Rcpp.h>
 #include <vector>
 #include <cfloat>


### PR DESCRIPTION
This PR adds the necessary array headers to fix issue when installing as documented:
```
devtools::install_github("xia-lab/OptiLCMS", build = TRUE, build_vignettes = FALSE, build_manual =TRUE)
```
resulting in error
```
...
-D_FORTIFY_SOURCE=2 -g -c mzClust.cpp -o mzClust.o mzClust.cpp: In function ‘Rcpp::IntegerVector R_mzClust_hclust_rcpp(Rcpp::NumericVector, int, Rcpp::NumericVector, double, double)’: mzClust.cpp:25:21: error: variable ‘std::array<int, 2> minclust’ has initializer but incomplete type 25 | std::array<int,2> minclust = {0,0}; | ^~~~~~~~ make: *** [/usr/local/lib/R/etc/Makeconf:211: mzClust.o] Error 1 ERROR: compilation failed for package ‘OptiLCMS’ * removing ‘/usr/local/lib/R/site-library/OptiLCMS’ Warning message: In i.p(...) : installation of package ‘/tmp/Rtmp0XplnZ/file19dabf41adffe5/OptiLCMS_1.2.0.tar.gz’ had non-zero exit status >
```